### PR TITLE
(hotfix) Patches CVE-2018-17567

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'jekyll', '~> 2.5.3'
+gem "jekyll", ">= 3.6.3"
 gem 'rdiscount','~> 2.2.0'
 
 group :jekyll_plugins do


### PR DESCRIPTION
 Changed:
   - updated to jekyll version 3.6.3